### PR TITLE
Bug fix when raven config is not defined

### DIFF
--- a/RavenGrailsPlugin.groovy
+++ b/RavenGrailsPlugin.groovy
@@ -6,7 +6,7 @@ import grails.plugins.raven.RavenClient
 import grails.plugins.raven.Configuration
 
 class RavenGrailsPlugin {
-    def version = "0.5.2"
+    def version = "0.5.3-SNAPSHOT"
     def clientVersion = "Raven-grails $version"
     def grailsVersion = "1.3.9 > *"
     def dependsOn = [:]

--- a/application.properties
+++ b/application.properties
@@ -1,4 +1,4 @@
 #Grails Metadata file
-#Fri Oct 19 11:17:44 BRT 2012
-app.grails.version=2.1.2
+#Wed Jan 09 16:17:59 CET 2013
+app.grails.version=2.2.0
 app.name=raven

--- a/grails-app/conf/Config.groovy
+++ b/grails-app/conf/Config.groovy
@@ -37,3 +37,5 @@ log4j = {
         warn 'stdout'
     }
 }
+grails.views.default.codec="none" // none, html, base64
+grails.views.gsp.encoding="UTF-8"

--- a/src/groovy/grails/plugins/raven/Configuration.groovy
+++ b/src/groovy/grails/plugins/raven/Configuration.groovy
@@ -20,20 +20,24 @@ class Configuration {
     Configuration(Map options = [:]) throws RavenException {
         options.each { k,v -> if (this.hasProperty(k)) { this."$k" = v} }
 
-        URL url = new URL(dsn)
-        this.protocol = url.protocol
-        this.host = url.host
+        if (dsn) {
+            URL url = new URL(dsn)
+            this.protocol = url.protocol
+            this.host = url.host
 
-        String userInfo = url.userInfo
-        String[] auth = userInfo.split(':')
-        this.secretKey = auth[1]
-        this.publicKey = auth[0]
+            String userInfo = url.userInfo
+            String[] auth = userInfo.split(':')
+            this.secretKey = auth[1]
+            this.publicKey = auth[0]
 
-        this.port = url.port
+            this.port = url.port
 
-        String[] path = url.path.split('/')
-        this.projectId = path[-1]
-        this.path = path[0..-2].join('/')
+            String[] path = url.path.split('/')
+            this.projectId = path[-1]
+            this.path = path[0..-2].join('/')
+        } else {
+            active = false
+        }
     }
 
     String getSentryURL() {

--- a/web-app/WEB-INF/applicationContext.xml
+++ b/web-app/WEB-INF/applicationContext.xml
@@ -6,37 +6,28 @@ http://www.springframework.org/schema/beans http://www.springframework.org/schem
 
 	<bean id="grailsApplication" class="org.codehaus.groovy.grails.commons.GrailsApplicationFactoryBean">
 		<description>Grails application factory bean</description>
-        <property name="grailsDescriptor" value="/WEB-INF/grails.xml" />
-        <property name="grailsResourceLoader" ref="grailsResourceLoader" />
+		<property name="grailsDescriptor" value="/WEB-INF/grails.xml" />
+		<property name="grailsResourceLoader" ref="grailsResourceLoader" />
 	</bean>
 
 	<bean id="pluginManager" class="org.codehaus.groovy.grails.plugins.GrailsPluginManagerFactoryBean">
 		<description>A bean that manages Grails plugins</description>
-        <property name="grailsDescriptor" value="/WEB-INF/grails.xml" />
-        <property name="application" ref="grailsApplication" />
+		<property name="grailsDescriptor" value="/WEB-INF/grails.xml" />
+		<property name="application" ref="grailsApplication" />
 	</bean>
 
-    <bean id="grailsConfigurator" class="org.codehaus.groovy.grails.commons.spring.GrailsRuntimeConfigurator">
-        <constructor-arg>
-            <ref bean="grailsApplication" />
-        </constructor-arg>
-        <property name="pluginManager" ref="pluginManager" />
-    </bean>
+	<bean id="grailsConfigurator" class="org.codehaus.groovy.grails.commons.spring.GrailsRuntimeConfigurator">
+		<constructor-arg>
+			<ref bean="grailsApplication" />
+		</constructor-arg>
+		<property name="pluginManager" ref="pluginManager" />
+	</bean>
 
-    <bean id="grailsResourceLoader" class="org.codehaus.groovy.grails.commons.GrailsResourceLoaderFactoryBean">
-        <property name="grailsResourceHolder" ref="grailsResourceHolder" />
-    </bean>
+	<bean id="grailsResourceLoader" class="org.codehaus.groovy.grails.commons.GrailsResourceLoaderFactoryBean" />
 
-    <bean id="grailsResourceHolder" scope="prototype" class="org.codehaus.groovy.grails.commons.spring.GrailsResourceHolder">
-        <property name="resources">
-              <value>classpath*:**/grails-app/**/*.groovy</value>
-        </property>
-    </bean>    
-    
-   <bean id="characterEncodingFilter"
-      class="org.springframework.web.filter.CharacterEncodingFilter">
-        <property name="encoding">
-          <value>utf-8</value>
-        </property>
-   </bean>    	
+	<bean id="characterEncodingFilter" class="org.springframework.web.filter.CharacterEncodingFilter">
+		<property name="encoding">
+			<value>utf-8</value>
+		</property>
+	</bean>
 </beans>

--- a/web-app/WEB-INF/sitemesh.xml
+++ b/web-app/WEB-INF/sitemesh.xml
@@ -5,7 +5,7 @@
         <parser content-type="text/html;charset=ISO-8859-1"
             class="org.codehaus.groovy.grails.web.sitemesh.GrailsHTMLPageParser" />
         <parser content-type="text/html;charset=UTF-8"
-            class="org.codehaus.groovy.grails.web.sitemesh.GrailsHTMLPageParser" />            
+            class="org.codehaus.groovy.grails.web.sitemesh.GrailsHTMLPageParser" />
     </page-parsers>
 
     <decorator-mappers>

--- a/web-app/WEB-INF/tld/c.tld
+++ b/web-app/WEB-INF/tld/c.tld
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
-<taglib xmlns="http://java.sun.com/xml/ns/j2ee"
+<taglib xmlns="http://java.sun.com/xml/ns/javaee"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://java.sun.com/xml/ns/j2ee http://java.sun.com/xml/ns/j2ee/web-jsptaglibrary_2_0.xsd"
-    version="2.0">
-    
-  <description>JSTL 1.1 core library</description>
+    xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-jsptaglibrary_2_1.xsd"
+    version="2.1">
+
+  <description>JSTL 1.2 core library</description>
   <display-name>JSTL core</display-name>
-  <tlib-version>1.1</tlib-version>
+  <tlib-version>1.2</tlib-version>
   <short-name>c</short-name>
   <uri>http://java.sun.com/jsp/jstl/core</uri>
 
@@ -74,7 +74,7 @@ not the body content should be processed.
         <description>
 Name of the exported scoped variable for the
 resulting value of the test condition. The type
-of the scoped variable is Boolean.        
+of the scoped variable is Boolean.
         </description>
         <name>var</name>
         <required>false</required>
@@ -174,6 +174,9 @@ Collection of items to iterate over.
 	<required>false</required>
 	<rtexprvalue>true</rtexprvalue>
 	<type>java.lang.Object</type>
+        <deferred-value>
+	    <type>java.lang.Object</type>
+        </deferred-value>
     </attribute>
     <attribute>
         <description>
@@ -253,6 +256,9 @@ String of tokens to iterate over.
 	<required>true</required>
 	<rtexprvalue>true</rtexprvalue>
 	<type>java.lang.String</type>
+        <deferred-value>
+	    <type>java.lang.String</type>
+        </deferred-value>
     </attribute>
     <attribute>
         <description>
@@ -322,7 +328,7 @@ visibility.
   <tag>
     <description>
         Like &lt;%= ... &gt;, but for expressions.
-    </description> 
+    </description>
     <name>out</name>
     <tag-class>org.apache.taglibs.standard.tag.rt.core.OutTag</tag-class>
     <body-content>JSP</body-content>
@@ -467,6 +473,9 @@ Expression to be evaluated.
         <name>value</name>
         <required>false</required>
         <rtexprvalue>true</rtexprvalue>
+        <deferred-value>
+	    <type>java.lang.Object</type>
+        </deferred-value>
     </attribute>
     <attribute>
         <description>

--- a/web-app/WEB-INF/tld/fmt.tld
+++ b/web-app/WEB-INF/tld/fmt.tld
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
-<taglib xmlns="http://java.sun.com/xml/ns/j2ee"
+<taglib xmlns="http://java.sun.com/xml/ns/javaee"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://java.sun.com/xml/ns/j2ee http://java.sun.com/xml/ns/j2ee/web-jsptaglibrary_2_0.xsd"
-    version="2.0">
-    
-  <description>JSTL 1.1 i18n-capable formatting library</description>
+    xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-jsptaglibrary_2_1.xsd"
+    version="2.1">
+
+  <description>JSTL 1.2 i18n-capable formatting library</description>
   <display-name>JSTL fmt</display-name>
-  <tlib-version>1.1</tlib-version>
+  <tlib-version>1.2</tlib-version>
   <short-name>fmt</short-name>
   <uri>http://java.sun.com/jsp/jstl/fmt</uri>
 
@@ -55,7 +55,7 @@ and may contain a two-letter (upper-case)
 country code (as defined by ISO-3166).
 Language and country codes must be
 separated by hyphen (-) or underscore
-(_).        
+(_).
 	</description>
         <name>value</name>
         <required>true</required>
@@ -496,7 +496,7 @@ Date and/or time to be formatted.
         <description>
 Specifies whether the time, the date, or both
 the time and date components of the given
-date are to be formatted. 
+date are to be formatted.
         </description>
         <name>type</name>
         <required>false</required>


### PR DESCRIPTION
Hi,

I just made some minor changes:
- upgrade to Grails 2.2,
- bug fix when raven config is not defined.

When we install current plugin, it breaks our apps and plugins build because it requires a raven DSN in the config.
If you don't provide a DSN with a valid URL, it generates a malformed URL exception when the grails app is packaged.
We don't use Sentry in dev/test environment, so we don't need to specify any Sentry/Raven config.

To solve this issue, I made a small change in Configuration.groovy so that _active_ is set to false if no DSN are defined in config.

I've updated the version to 0.5.3-SNAPSHOT, you might want to remove the -SNAPSHOT part when you release the plugin.

Thanks!

Ben
