### PR TITLE
Remove commons codec Base64 dependency when building message body (for G...

### DIFF
--- a/RavenGrailsPlugin.groovy
+++ b/RavenGrailsPlugin.groovy
@@ -6,7 +6,7 @@ import grails.plugins.raven.RavenClient
 import grails.plugins.raven.Configuration
 
 class RavenGrailsPlugin {
-    def version = "0.5.3-SNAPSHOT"
+    def version = "0.5.4-SNAPSHOT"
     def clientVersion = "Raven-grails $version"
     def grailsVersion = "1.3.9 > *"
     def dependsOn = [:]

--- a/application.properties
+++ b/application.properties
@@ -1,4 +1,4 @@
 #Grails Metadata file
-#Wed Jan 09 16:17:59 CET 2013
-app.grails.version=2.2.0
+#Sat Dec 28 13:30:13 CET 2013
+app.grails.version=2.3.4
 app.name=raven

--- a/grails-app/conf/BuildConfig.groovy
+++ b/grails-app/conf/BuildConfig.groovy
@@ -1,32 +1,31 @@
-grails.project.class.dir = "target/classes"
-grails.project.test.class.dir = "target/test-classes"
-grails.project.test.reports.dir = "target/test-reports"
+grails.servlet.version = '3.0' // Change depending on target container compliance (2.5 or 3.0)
+grails.project.class.dir = 'target/classes'
+grails.project.test.class.dir = 'target/test-classes'
+grails.project.test.reports.dir = 'target/test-reports'
+grails.project.work.dir = 'target/work'
+grails.project.target.level = 1.6
+grails.project.source.level = 1.6
 
+grails.project.dependency.resolver = 'maven'
 grails.project.dependency.resolution = {
     // inherit Grails' default dependencies
-    inherits("global") {
-        // uncomment to disable ehcache
+    inherits('global') {
+        // specify dependency exclusions here; for example, uncomment this to disable ehcache:
         // excludes 'ehcache'
     }
-    log "warn" // log level of Ivy resolver, either 'error', 'warn', 'info', 'debug' or 'verbose'
-    repositories {
-        grailsPlugins()
-        grailsHome()
-        grailsCentral()
+    log 'error' // log level of Ivy resolver, either 'error', 'warn', 'info', 'debug' or 'verbose'
+    checksums true // Whether to verify checksums on resolve
+    legacyResolve false // whether to do a secondary resolve on plugin installation, not advised and here for backwards compatibility
 
-        // uncomment the below to enable remote dependency resolution
-        // from public Maven repositories
+    repositories {
+        grailsCentral()
         mavenLocal()
         mavenCentral()
-        //mavenRepo "http://snapshots.repository.codehaus.org"
-        //mavenRepo "http://repository.codehaus.org"
-        //mavenRepo "http://download.java.net/maven/2/"
-        //mavenRepo "http://repository.jboss.com/maven2/"
+    }
+    dependencies {
     }
     plugins {
-        build(":tomcat:$grailsVersion",
-              ":release:2.2.0",
-              ":rest-client-builder:1.0.3") {
+        build(':release:3.0.1', ':rest-client-builder:1.0.3') {
             export = false
         }
     }

--- a/grails-app/conf/Config.groovy
+++ b/grails-app/conf/Config.groovy
@@ -39,3 +39,27 @@ log4j = {
 }
 grails.views.default.codec="none" // none, html, base64
 grails.views.gsp.encoding="UTF-8"
+
+// Uncomment and edit the following lines to start using Grails encoding & escaping improvements
+
+/* remove this line 
+// GSP settings
+grails {
+    views {
+        gsp {
+            encoding = 'UTF-8'
+            htmlcodec = 'xml' // use xml escaping instead of HTML4 escaping
+            codecs {
+                expression = 'html' // escapes values inside null
+                scriptlet = 'none' // escapes output from scriptlets in GSPs
+                taglib = 'none' // escapes output from taglibs
+                staticparts = 'none' // escapes output from static template parts
+            }
+        }
+        // escapes all not-encoded output at final stage of outputting
+        filteringCodecForContentType {
+            //'text/html' = 'html'
+        }
+    }
+}
+remove this line */

--- a/src/groovy/grails/plugins/raven/RavenClient.groovy
+++ b/src/groovy/grails/plugins/raven/RavenClient.groovy
@@ -7,7 +7,6 @@ import javax.servlet.http.HttpServletRequestWrapper
 import org.apache.commons.lang.time.DateFormatUtils
 import org.apache.log4j.Level
 import org.apache.log4j.spi.LoggingEvent
-import static org.apache.commons.codec.binary.Base64.encodeBase64String
 import org.springframework.web.context.request.RequestContextHolder
 import org.codehaus.groovy.grails.web.servlet.mvc.GrailsWebRequest
 import grails.plugins.raven.interfaces.User
@@ -81,7 +80,7 @@ class RavenClient {
     }
 
     private String buildMessageBody(String jsonMessage) {
-        return encodeBase64String(jsonMessage.getBytes())
+        return jsonMessage.bytes.encodeBase64().toString()
     }
 
     def setUserData(Map user) {

--- a/web-app/WEB-INF/applicationContext.xml
+++ b/web-app/WEB-INF/applicationContext.xml
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
-       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xsi:schemaLocation="
-http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.5.xsd">
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<bean id="grailsApplication" class="org.codehaus.groovy.grails.commons.GrailsApplicationFactoryBean">
 		<description>Grails application factory bean</description>
@@ -30,4 +29,6 @@ http://www.springframework.org/schema/beans http://www.springframework.org/schem
 			<value>utf-8</value>
 		</property>
 	</bean>
+
+	<bean id="conversionService" class="org.springframework.context.support.ConversionServiceFactoryBean" />
 </beans>

--- a/web-app/WEB-INF/tld/spring.tld
+++ b/web-app/WEB-INF/tld/spring.tld
@@ -1,311 +1,457 @@
-<?xml version="1.0" encoding="ISO-8859-1" ?>
-<!DOCTYPE taglib PUBLIC "-//Sun Microsystems, Inc.//DTD JSP Tag Library 1.2//EN" "http://java.sun.com/dtd/web-jsptaglibrary_1_2.dtd">
+<?xml version="1.0" encoding="UTF-8"?>
+<taglib xmlns="http://java.sun.com/xml/ns/j2ee"
+		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		xsi:schemaLocation="http://java.sun.com/xml/ns/j2ee http://java.sun.com/xml/ns/j2ee/web-jsptaglibrary_2_0.xsd"
+		version="2.0">
 
-<taglib>
-
-	<tlib-version>1.1.1</tlib-version>
-
-	<jsp-version>1.2</jsp-version>
-
-	<short-name>Spring</short-name>
-
+	<description>Spring Framework JSP Tag Library</description>
+	<tlib-version>3.0</tlib-version>
+	<short-name>spring</short-name>
 	<uri>http://www.springframework.org/tags</uri>
 
-	<description>Spring Framework JSP Tag Library. Authors: Rod Johnson, Juergen Hoeller</description>
-
-
 	<tag>
-
-		<name>htmlEscape</name>
-		<tag-class>org.springframework.web.servlet.tags.HtmlEscapeTag</tag-class>
-		<body-content>JSP</body-content>
-
 		<description>
 			Sets default HTML escape value for the current page.
 			Overrides a "defaultHtmlEscape" context-param in web.xml, if any.
 		</description>
-
+		<name>htmlEscape</name>
+		<tag-class>org.springframework.web.servlet.tags.HtmlEscapeTag</tag-class>
+		<body-content>JSP</body-content>
 		<attribute>
+			<description>Set the default value for HTML escaping, to be put
+				into the current PageContext.</description>
 			<name>defaultHtmlEscape</name>
 			<required>true</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
-
 	</tag>
 
-
 	<tag>
-
-		<name>escapeBody</name>
-		<tag-class>org.springframework.web.servlet.tags.EscapeBodyTag</tag-class>
-		<body-content>JSP</body-content>
-
 		<description>
 			Escapes its enclosed body content, applying HTML escaping and/or JavaScript escaping.
 			The HTML escaping flag participates in a page-wide or application-wide setting
 			(i.e. by HtmlEscapeTag or a "defaultHtmlEscape" context-param in web.xml).
 		</description>
-
+		<name>escapeBody</name>
+		<tag-class>org.springframework.web.servlet.tags.EscapeBodyTag</tag-class>
+		<body-content>JSP</body-content>
 		<attribute>
+			<description>Set HTML escaping for this tag, as boolean value. Overrides the
+			default HTML escaping setting for the current page.</description>
 			<name>htmlEscape</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
-
 		<attribute>
+			<description>Set JavaScript escaping for this tag, as boolean value.
+			Default is false.</description>
 			<name>javaScriptEscape</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
-
 	</tag>
 
-
 	<tag>
-
-		<name>message</name>
-		<tag-class>org.springframework.web.servlet.tags.MessageTag</tag-class>
-		<body-content>JSP</body-content>
-
 		<description>
 			Retrieves the message with the given code, or text if code isn't resolvable.
 			The HTML escaping flag participates in a page-wide or application-wide setting
 			(i.e. by HtmlEscapeTag or a "defaultHtmlEscape" context-param in web.xml).
 		</description>
-
+		<name>message</name>
+		<tag-class>org.springframework.web.servlet.tags.MessageTag</tag-class>
+		<body-content>JSP</body-content>
 		<attribute>
+			<description>A MessageSourceResolvable argument (direct or through JSP EL).
+				Fits nicely when used in conjunction with Spring's own validation error
+				classes which all implement the MessageSourceResolvable interface. For
+				example, this allows you to iterate over all of the errors in a form,
+				passing each error (using a runtime expression) as the value of this
+				'message' attribute, thus effecting the easy display of such error
+				messages.</description>
+			<name>message</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<description>The code (key) to use when looking up the message.
+			If code is not provided, the text attribute will be used.</description>
 			<name>code</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
-
 		<attribute>
+			<description>Set optional message arguments for this tag, as a
+			(comma-)delimited String (each String argument can contain JSP EL),
+			an Object array (used as argument array), or a single Object (used
+			as single argument).</description>
 			<name>arguments</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
-
 		<attribute>
+			<description>The separator character to be used for splitting the
+			arguments string value; defaults to a 'comma' (',').</description>
+			<name>argumentSeparator</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<description>Default text to output when a message for the given code
+			could not be found. If both text and code are not set, the tag will
+			output null.</description>
 			<name>text</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
-
 		<attribute>
+			<description>The string to use when binding the result to the page,
+			request, session or application scope. If not specified, the result
+			gets outputted to the writer (i.e. typically directly to the JSP).</description>
 			<name>var</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
-
 		<attribute>
+			<description>The scope to use when exporting the result to a variable.
+			This attribute is only used when var is also set. Possible values are
+			page, request, session and application.</description>
 			<name>scope</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
-
 		<attribute>
+			<description>Set HTML escaping for this tag, as boolean value.
+			Overrides the default HTML escaping setting for the current page.</description>
 			<name>htmlEscape</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
-
 		<attribute>
+			<description>Set JavaScript escaping for this tag, as boolean value. Default is false.</description>
 			<name>javaScriptEscape</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
-
 	</tag>
 
-
 	<tag>
-
-		<name>theme</name>
-		<tag-class>org.springframework.web.servlet.tags.ThemeTag</tag-class>
-		<body-content>JSP</body-content>
-
 		<description>
 			Retrieves the theme message with the given code, or text if code isn't resolvable.
 			The HTML escaping flag participates in a page-wide or application-wide setting
 			(i.e. by HtmlEscapeTag or a "defaultHtmlEscape" context-param in web.xml).
 		</description>
-
+		<name>theme</name>
+		<tag-class>org.springframework.web.servlet.tags.ThemeTag</tag-class>
+		<body-content>JSP</body-content>
 		<attribute>
+			<description>A MessageSourceResolvable argument (direct or through JSP EL).</description>
+			<name>message</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<description>The code (key) to use when looking up the message.
+			If code is not provided, the text attribute will be used.</description>
 			<name>code</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
-
 		<attribute>
+			<description>Set optional message arguments for this tag, as a
+			(comma-)delimited String (each String argument can contain JSP EL),
+			an Object array (used as argument array), or a single Object (used
+			as single argument).</description>
 			<name>arguments</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
-
 		<attribute>
+			<description>The separator character to be used for splitting the
+			arguments string value; defaults to a 'comma' (',').</description>
+			<name>argumentSeparator</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<description>Default text to output when a message for the given code
+			could not be found. If both text and code are not set, the tag will
+			output null.</description>
 			<name>text</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
-
 		<attribute>
+			<description>The string to use when binding the result to the page,
+			request, session or application scope. If not specified, the result
+			gets outputted to the writer (i.e. typically directly to the JSP).</description>
 			<name>var</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
-
 		<attribute>
+			<description>The scope to use when exporting the result to a variable.
+			This attribute is only used when var is also set. Possible values are
+			page, request, session and application.</description>
 			<name>scope</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
-
 		<attribute>
+			<description>Set HTML escaping for this tag, as boolean value.
+			Overrides the default HTML escaping setting for the current page.</description>
 			<name>htmlEscape</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
-
 		<attribute>
+			<description>Set JavaScript escaping for this tag, as boolean value. Default is false.</description>
 			<name>javaScriptEscape</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
-
 	</tag>
 
-
 	<tag>
-
-		<name>hasBindErrors</name>
-		<tag-class>org.springframework.web.servlet.tags.BindErrorsTag</tag-class>
-		<body-content>JSP</body-content>
-
 		<description>
 			Provides Errors instance in case of bind errors.
 			The HTML escaping flag participates in a page-wide or application-wide setting
 			(i.e. by HtmlEscapeTag or a "defaultHtmlEscape" context-param in web.xml).
 		</description>
-
+		<name>hasBindErrors</name>
+		<tag-class>org.springframework.web.servlet.tags.BindErrorsTag</tag-class>
+		<body-content>JSP</body-content>
 		<variable>
 			<name-given>errors</name-given>
 			<variable-class>org.springframework.validation.Errors</variable-class>
 		</variable>
-
 		<attribute>
+			<description>The name of the bean in the request, that needs to be
+			inspected for errors. If errors are available for this bean, they
+			will be bound under the 'errors' key.</description>
 			<name>name</name>
 			<required>true</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
-
 		<attribute>
+			<description>Set HTML escaping for this tag, as boolean value.
+			Overrides the default HTML escaping setting for the current page.</description>
 			<name>htmlEscape</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
-
 	</tag>
 
-
 	<tag>
-
-		<name>nestedPath</name>
-		<tag-class>org.springframework.web.servlet.tags.NestedPathTag</tag-class>
-		<body-content>JSP</body-content>
-
 		<description>
 			Sets a nested path to be used by the bind tag's path.
 		</description>
-
+		<name>nestedPath</name>
+		<tag-class>org.springframework.web.servlet.tags.NestedPathTag</tag-class>
+		<body-content>JSP</body-content>
 		<variable>
 			<name-given>nestedPath</name-given>
 			<variable-class>java.lang.String</variable-class>
 		</variable>
-
 		<attribute>
+			<description>Set the path that this tag should apply. E.g. 'customer'
+			to allow bind paths like 'address.street' rather than
+			'customer.address.street'.</description>
 			<name>path</name>
 			<required>true</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
-
 	</tag>
 
-
 	<tag>
-
-		<name>bind</name>
-		<tag-class>org.springframework.web.servlet.tags.BindTag</tag-class>
-		<body-content>JSP</body-content>
-
 		<description>
 			Provides BindStatus object for the given bind path.
 			The HTML escaping flag participates in a page-wide or application-wide setting
 			(i.e. by HtmlEscapeTag or a "defaultHtmlEscape" context-param in web.xml).
 		</description>
-
+		<name>bind</name>
+		<tag-class>org.springframework.web.servlet.tags.BindTag</tag-class>
+		<body-content>JSP</body-content>
 		<variable>
 			<name-given>status</name-given>
 			<variable-class>org.springframework.web.servlet.support.BindStatus</variable-class>
 		</variable>
-
 		<attribute>
+			<description>The path to the bean or bean property to bind status
+			information for. For instance account.name, company.address.zipCode
+			or just employee. The status object will exported to the page scope,
+			specifically for this bean or bean property</description>
 			<name>path</name>
 			<required>true</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
-
 		<attribute>
+			<description>Set whether to ignore a nested path, if any. Default is to not ignore.</description>
 			<name>ignoreNestedPath</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
-
 		<attribute>
+			<description>Set HTML escaping for this tag, as boolean value. Overrides
+			the default HTML escaping setting for the current page.</description>
 			<name>htmlEscape</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
-
 	</tag>
 
-
 	<tag>
-
-		<name>transform</name>
-		<tag-class>org.springframework.web.servlet.tags.TransformTag</tag-class>
-		<body-content>JSP</body-content>
-
 		<description>
 			Provides transformation of variables to Strings, using an appropriate
 			custom PropertyEditor from BindTag (can only be used inside BindTag).
 			The HTML escaping flag participates in a page-wide or application-wide setting
-			(i.e. by HtmlEscapeTag or a "defaultHtmlEscape" context-param in web.xml).
+			(i.e. by HtmlEscapeTag or a 'defaultHtmlEscape' context-param in web.xml).
 		</description>
-
+		<name>transform</name>
+		<tag-class>org.springframework.web.servlet.tags.TransformTag</tag-class>
+		<body-content>JSP</body-content>
 		<attribute>
+			<description>The value to transform. This is the actual object you want
+			to have transformed (for instance a Date). Using the PropertyEditor that
+			is currently in use by the 'spring:bind' tag.</description>
 			<name>value</name>
 			<required>true</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
-
 		<attribute>
+			<description>The string to use when binding the result to the page,
+			request, session or application scope. If not specified, the result gets
+			outputted to the writer (i.e. typically directly to the JSP).</description>
 			<name>var</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
-
 		<attribute>
+			<description>The scope to use when exported the result to a variable.
+			This attribute is only used when var is also set. Possible values are
+			page, request, session and application.</description>
 			<name>scope</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
-
 		<attribute>
+			<description>Set HTML escaping for this tag, as boolean value. Overrides
+			the default HTML escaping setting for the current page.</description>
 			<name>htmlEscape</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
+	</tag>
 
+	<tag>
+		<description>URL tag based on the JSTL c:url tag.  This variant is fully 
+		backwards compatible with the standard tag.  Enhancements include support 
+		for URL template parameters.</description>
+		<name>url</name>
+		<tag-class>org.springframework.web.servlet.tags.UrlTag</tag-class>
+		<body-content>JSP</body-content>
+		<attribute>
+			<description>The URL to build.  This value can include template place holders 
+			that are replaced with the URL encoded value of the named parameter.  Parameters 
+			must be defined using the param tag inside the body of this tag.</description>
+			<name>value</name>
+			<required>true</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<description>Specifies a remote application context path.  The default is the 
+			current application context path.</description>
+			<name>context</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<description>The name of the variable to export the URL value to.</description>
+			<name>var</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<description>The scope for the var.  'application', 'session', 'request' and 
+			'page' scopes are supported.  Defaults to page scope.  This attribute has no 
+			effect unless the var attribute is also defined.</description>
+			<name>scope</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<description>Set HTML escaping for this tag, as a boolean value. Overrides the
+			default HTML escaping setting for the current page.</description>
+			<name>htmlEscape</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<description>Set JavaScript escaping for this tag, as a boolean value.
+			Default is false.</description>
+			<name>javaScriptEscape</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+	</tag>
+
+	<tag>
+		<description>Parameter tag based on the JSTL c:param tag.  The sole purpose is to 
+		support params inside the spring:url tag.</description>
+		<name>param</name>
+		<tag-class>org.springframework.web.servlet.tags.ParamTag</tag-class>
+		<body-content>JSP</body-content>
+		<attribute>
+			<description>The name of the parameter.</description>
+			<name>name</name>
+			<required>true</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<description>The value of the parameter.</description>
+			<name>value</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+	</tag>
+
+	<tag>
+		<description>Evaluates a Spring expression (SpEL) and either prints the result or assigns it to a variable.</description>
+		<name>eval</name>
+		<tag-class>org.springframework.web.servlet.tags.EvalTag</tag-class>
+		<body-content>JSP</body-content>
+		<attribute>
+			<description>The expression to evaluate.</description>
+			<name>expression</name>
+			<required>true</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<description>The name of the variable to export the evaluation result to.</description>
+			<name>var</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<description>The scope for the var.  'application', 'session', 'request' and 
+			'page' scopes are supported.  Defaults to page scope.  This attribute has no 
+			effect unless the var attribute is also defined.</description>
+			<name>scope</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<description>Set HTML escaping for this tag, as a boolean value. Overrides the
+			default HTML escaping setting for the current page.</description>
+			<name>htmlEscape</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<description>Set JavaScript escaping for this tag, as a boolean value.  Default is false.</description>
+			<name>javaScriptEscape</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
 	</tag>
 
 </taglib>


### PR DESCRIPTION
RavenClient does not work anymore with Grails 2.3.
It throws an exception when trying to call `org.apache.commons.codec.binary.Base64.encodeBase64String` in RavenClient.

So I've replaced it to use native Groovy method to encode in Base64 and it solves the issue.
