### PR TITLE
fix for missing property in RavenClient

### DIFF
--- a/src/groovy/grails/plugins/raven/RavenClient.groovy
+++ b/src/groovy/grails/plugins/raven/RavenClient.groovy
@@ -31,7 +31,7 @@ class RavenClient {
     }
 
     def captureMessage(String message, String loggerName, String logLevel) {
-        send(exception.getMessage(), null, loggerName, logLevel, null, null)
+        send(message, null, loggerName, logLevel, null, null)
     }
 
     def captureException(Throwable exception) {


### PR DESCRIPTION
Hi!
In the overloaded captureMessage method, the exception object is not available.

`groovy.lang.MissingPropertyException: No such property: exception for class: grails.plugins.raven.RavenClient`
